### PR TITLE
Update wordcount and preface

### DIFF
--- a/plugin/commands/txt_send_cmd.rb
+++ b/plugin/commands/txt_send_cmd.rb
@@ -10,7 +10,7 @@ module AresMUSH
           # if (!cmd.args)
           #   #why is this here?
           #   self.names = []
-          #  IF YOU PUT THIS BACK IN, CHANGE NEXT LIKE TO ELSIF
+          #  IF YOU PUT THIS BACK IN, CHANGE NEXT LINE TO ELSIF
 
           if (cmd.args.start_with?("="))
             self.names = enactor.txt_last
@@ -167,6 +167,7 @@ module AresMUSH
 
           enactor.update(txt_last: list_arg(recipient_names))
           enactor.update(txt_scene: self.scene_id)
+          Scenes.handle_word_count_achievements(enactor, message)
       end
 
       def log_command

--- a/plugin/helpers.rb
+++ b/plugin/helpers.rb
@@ -71,7 +71,6 @@ module AresMUSH
       end
 
       def self.txt_recipient(sender, recipient, recipient_names, message, scene_id = nil)
-        Scenes.handle_word_count_achievements(sender, message)
         client = Login.find_client(sender)
         recipient_client  = Login.find_client(recipient)
         Login.emit_if_logged_in recipient, message

--- a/plugin/locales/locale_en.yml
+++ b/plugin/locales/locale_en.yml
@@ -2,9 +2,9 @@
 en:
   txt:
       #Text Message Formatting
-      txt_no_scene_id: "%{txt} %xh%xw %{sender}%xn: %{message}%xn"
-      txt_no_scene_id_nick: "%{txt} %xh%{sender}%xn: %{message} %xx%xh(%{sender_char})%xn"
-      txt_with_scene_id: "%{txt} %xh%{sender}%xn: %{message} %xx%xh(Scene %{scene_id})%xn"
+      txt_no_scene_id: "%{txt} %xh%xw%{sender}:%xn %{message}%xn"
+      txt_no_scene_id_nick: "%{txt} %xh%w%{sender}:%xn %{message} %xx%xh(%{sender_char})%xn"
+      txt_with_scene_id: "%{txt} %xh%xw%{sender}:%xn %{message} %xx%xh(Scene %{scene_id})%xn"
 
 
       txt_target_missing: "Beep boop: To whom shall I send this message?"
@@ -15,13 +15,13 @@ en:
       recipient_added_to_scene: "That text has added %{name} to the scene participants list."
       no_such_character: "No character found by that name."
 
-      no_one_to_reply_to: "Looks like no one's txt'd you recently. Sorry."
+      no_one_to_reply_to: "Looks like no one's txted you recently. Sorry."
       reply_scene: "Last txt came from: %{names}; Scene: %{scene}"
       reply: "Last txt came from: %{names}"
 
       recipient_indicator: "%{recipients}"
 
-      txt_indicator: "%{color}%{start_marker}%{preface} to %{recipients}%{color}%{end_marker}%xn"
+      txt_indicator: "%{color}%{start_marker}%{preface} to %{recipients}%{end_marker}%xn"
 
       color_set: "Txts will now appear with this marker: %{option}%%%xn"
 

--- a/plugin/web/add_txt_handler.rb
+++ b/plugin/web/add_txt_handler.rb
@@ -135,7 +135,7 @@ module AresMUSH
                 :sender => sender_display_name,
                 :message => message )
                 Scenes.add_to_scene(scene, scene_txt, char)
-                Scenes.handle_word_count_achievements(enactor, message)
+                Scenes.handle_word_count_achievements(char, message)
 
                 room_txt = t('txt.txt_with_scene_id',
                 :txt => Txt.format_txt_indicator(char, recipient_display_names),


### PR DESCRIPTION
Previous update was adding to logged in char's wordcount rather than txting char's, on portal, and counting the preface in the wordcount on client. Also could not find situations where the extra ansi code was needed in the preface, so removed it along with an extra space.